### PR TITLE
Add partial_allow_local compiler option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ convert to a hexadecimal string:
 ## Modules ##
 
 <table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/jkrukoff/partial/blob/compiler-flags/doc/partial.md" class="module">partial</a></td></tr></table>
+<tr><td><a href="http://github.com/jkrukoff/partial/blob/master/doc/partial.md" class="module">partial</a></td></tr></table>
 
 
 ### Getting Started ###

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Not actually curry.](doc/curry.jpg)
 
+
 ### Overview ###
 
 This is an Erlang parse transform for partial function application, in the
@@ -20,10 +21,30 @@ convert to a hexadecimal string:
 "FF"
 ```
 
+
+## Modules ##
+
+<table width="100%" border="0" summary="list of modules">
+<tr><td><a href="http://github.com/jkrukoff/partial/blob/compiler-flags/doc/partial.md" class="module">partial</a></td></tr></table>
+
+
+### Getting Started ###
+
+This library is published to [hex.pm](https://hex.pm) as
+[partial](https://hex.pm/packages/partial). If you're using
+[rebar3](https://www.rebar3.org/) as your build tool, it can be added as a
+dependency to your rebar.config as follows:
+
+```
+
+{deps, [{partial}]}.
+```
+
 To use this parse transform, add the following to the top of any module after adding
 this library to your application:
 
 ```
+
 -compile({parse_transform, partial}).
 ```
 
@@ -47,7 +68,7 @@ once, when the partial function is constructed.
 
 #### Cuts ####
 
-Cuts are represented by the special variable `_`. As this variable is usually
+Cuts are represented by the special variable `_'. As this variable is usually
 only legal on the left hand side of a match expression, this use should not
 conflict with any existing Erlang syntax.
 
@@ -64,10 +85,7 @@ Rev3(fun lists:reverse/1).
 ```
 
 All, some or none of the arguments to a function may be cuts.
-
-
-#### Examples ####
-
+<h4>Examples</h4>
 Partial evaluation provides an easy way to work with higher order functions.
 For instance, to double the items in a list:
 
@@ -76,9 +94,9 @@ For instance, to double the items in a list:
 [2, 4, 6]
 ```
 
-The difference between partial:cut and partial:cute can be seen when dealing
-with functions with side effects. For instance, when we try and read a value
-from the process dictionary with get/1.
+The difference between `partial:cut/1` and `partial:cute/1` can be seen when
+dealing with functions with side effects. For instance, when we try and read a
+value from the process dictionary with `get/1`.
 
 ```
 > Identity = fun (X) -> X end,
@@ -96,7 +114,7 @@ from the process dictionary with get/1.
 1
 ```
 
-This also makes partial:cute an easy way to cache expensive computation and
+This also makes `partial:cute/1` an easy way to cache expensive computation and
 reuse it in later calls.
 
 Finally, partial evaluation can make creating pipelines across multiple
@@ -112,6 +130,19 @@ functions easier:
 ```
 
 
+#### Options ####
+
+The parse transform supports a single option: `partial_allow_local`. This
+option allows for a bare `cut/1` or `cute/1` call to be treated the same as
+the fully qualified `partial:cut/1` or `partial:cute/1` call.
+
+To enable, either pass as a compiler flag or specify as a compile attribute:
+
+```
+-compile(partial_allow_local).
+```
+
+
 ### Implementation ###
 
 The transformations are implemented as a replacement of the marker functions
@@ -121,7 +152,7 @@ erlang:apply/3 are not detected or rewritten and will result in a run time
 exception. The result of either transform is _always_ a fun
 expression, even when no unevaluated arguments are found.
 
-The underscore variable `_` is used as a placeholder for unevaluated
+The underscore variable `_' is used as a placeholder for unevaluated
 arguments. It is only legal as a standalone expression, as either the function
 name to call or as an argument. Unevaluated arguments are converted to
 arguments of the created fun in strict left to right order. There is no
@@ -141,7 +172,7 @@ Fun = fun (Arg1) ->
 end.
 ```
 
-partial:cute/1 is implemented as a transformation from:
+`partial:cute/1` is implemented as a transformation from:
 
 ```
 Fun = partial:cute(some_fun(X, Y, _)).
@@ -207,10 +238,3 @@ contains a similar parse transform, which was used for reference.
 Image by Cuklev
 
 CC BY-SA 4.0 [`https://creativecommons.org/licenses/by-sa/4.0`](https://creativecommons.org/licenses/by-sa/4.0)
-
-
-## Modules ##
-
-
-<table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/jkrukoff/partial/blob/master/doc/partial.md" class="module">partial</a></td></tr></table>

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2018 John Krukoff
 
-__Version:__ 1.0.0
+__Version:__ 1.2.0
 
 __Authors:__ John Krukoff ([`github@cultist.org`](mailto:github@cultist.org)).
 
@@ -17,7 +17,7 @@ This is an Erlang parse transform for partial function application, in the
 spirit of [Scheme's
 SRFI-26](https://srfi.schemers.org/srfi-26/srfi-26.md).
 
-It enables the use of cuts, as represented by the special variable "_",  to
+It enables the use of cuts, as represented by the special variable `_`,  to
 create anonymous functions with _some_ arguments applied.
 
 For example, to create a function which takes a single integer argument to
@@ -28,6 +28,17 @@ convert to a hexadecimal string:
 > Hex = partial:cut(integer_to_list(_, 16)),
 > Hex(255).
 "FF"
+```
+
+
+### Getting Started ###
+
+This library is published to [hex.pm](https://hex.pm) as [partial](https://hex.pm/packages/partial). If you're using [rebar3](https://www.rebar3.org/) as your build tool, it can be added
+as a dependency to your rebar.config as follows:
+
+```
+
+{deps, [{partial}]}.
 ```
 
 To use this parse transform, add the following to the top of any module after adding
@@ -60,7 +71,7 @@ once, when the partial function is constructed.
 
 #### Cuts ####
 
-Cuts are represented by the special variable "_". As this variable is usually
+Cuts are represented by the special variable `_`. As this variable is usually
 only legal on the left hand side of a match expression, this use should not
 conflict with any existing Erlang syntax.
 
@@ -85,15 +96,16 @@ For instance, to double the items in a list:
 [2, 4, 6]
 ```
 
-The difference between partial:cut and partial:cute can be seen when dealing
-with functions with side effects. For instance, when we try and read a value
-from the process dictionary with get/1.
+The difference between `partial:cut/1` and `partial:cute/1` can be seen when
+dealing with functions with side effects. For instance, when we try and read a
+value from the process dictionary with `get/1`.
 
 ```
 
+> Identity = fun (X) -> X end,
 > put(example, 1),
-> Cut = partial:cut(get(example)),
-> Cute = partial:cute(get(example)),
+> Cut = partial:cut(Identity(get(example))),
+> Cute = partial:cute(Identity(get(example))),
 > Cut().
 1
 > Cute().
@@ -105,7 +117,7 @@ from the process dictionary with get/1.
 1
 ```
 
-This also makes partial:cute an easy way to cache expensive computation and
+This also makes `partial:cute/1` an easy way to cache expensive computation and
 reuse it in later calls.
 
 Finally, partial evaluation can make creating pipelines across multiple
@@ -122,6 +134,20 @@ functions easier:
 ```
 
 
+#### Options ####
+
+The parse transform supports a single option: `partial_allow_local`. This
+option allows for a bare `cut/1` or `cute/1` call to be treated the same as
+the fully qualified `partial:cut/1` or `partial:cute/1` call.
+
+To enable, either pass as a compiler flag or specify as a compile attribute:
+
+```
+
+-compile(partial_allow_local).
+```
+
+
 ### Implementation ###
 
 The transformations are implemented as a replacement of the marker functions
@@ -131,7 +157,7 @@ erlang:apply/3 are not detected or rewritten and will result in a run time
 exception. The result of either transform is _always_ a fun
 expression, even when no unevaluated arguments are found.
 
-The underscore variable "_" is used as a placeholder for unevaluated
+The underscore variable `_` is used as a placeholder for unevaluated
 arguments. It is only legal as a standalone expression, as either the function
 name to call or as an argument. Unevaluated arguments are converted to
 arguments of the created fun in strict left to right order. There is no
@@ -153,7 +179,7 @@ Fun = fun (Arg1) ->
 end.
 ```
 
-partial:cute/1 is implemented as a transformation from:
+`partial:cute/1` is implemented as a transformation from:
 
 ```
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
 @author John Krukoff <github@cultist.org>
 @copyright 2018 John Krukoff
-@version 1.0.0
+@version 1.2.0
 @title partial
 @doc <h3>Overview</h3>
 
@@ -10,7 +10,7 @@ This is an Erlang parse transform for partial function application, in the
 spirit of <a href="https://srfi.schemers.org/srfi-26/srfi-26.html">Scheme's
 SRFI-26</a>.
 
-It enables the use of cuts, as represented by the special variable "_",  to
+It enables the use of cuts, as represented by the special variable `_',  to
 create anonymous functions with <em>some</em> arguments applied.
 
 For example, to create a function which takes a single integer argument to
@@ -20,6 +20,17 @@ convert to a hexadecimal string:
 > Hex = partial:cut(integer_to_list(_, 16)),
 > Hex(255).
 "FF"
+'''
+
+<h3>Getting Started</h3>
+
+This library is published to <a href="https://hex.pm">hex.pm</a> as <a
+href="https://hex.pm/packages/partial">partial</a>. If you're using <a
+href="https://www.rebar3.org/">rebar3</a> as your build tool, it can be added
+as a dependency to your rebar.config as follows:
+
+```
+{deps, [{partial}]}.
 '''
 
 To use this parse transform, add the following to the top of any module after adding
@@ -49,7 +60,7 @@ once, when the partial function is constructed.
 
 <h4>Cuts</h4>
 
-Cuts are represented by the special variable "_". As this variable is usually
+Cuts are represented by the special variable `_'. As this variable is usually
 only legal on the left hand side of a match expression, this use should not
 conflict with any existing Erlang syntax.
 
@@ -77,9 +88,9 @@ For instance, to double the items in a list:
 [2, 4, 6]
 '''
 
-The difference between partial:cut and partial:cute can be seen when dealing
-with functions with side effects. For instance, when we try and read a value
-from the process dictionary with get/1.
+The difference between `partial:cut/1' and `partial:cute/1' can be seen when
+dealing with functions with side effects. For instance, when we try and read a
+value from the process dictionary with `get/1'.
 
 ```
 > Identity = fun (X) -> X end,
@@ -97,7 +108,7 @@ from the process dictionary with get/1.
 1
 '''
 
-This also makes partial:cute an easy way to cache expensive computation and
+This also makes `partial:cute/1' an easy way to cache expensive computation and
 reuse it in later calls.
 
 Finally, partial evaluation can make creating pipelines across multiple
@@ -112,6 +123,18 @@ functions easier:
 [2, 4, 6]
 '''
 
+<h4>Options</h4>
+
+The parse transform supports a single option: `partial_allow_local'. This
+option allows for a bare `cut/1' or `cute/1' call to be treated the same as
+the fully qualified `partial:cut/1' or `partial:cute/1' call.
+
+To enable, either pass as a compiler flag or specify as a compile attribute:
+
+```
+-compile(partial_allow_local).
+'''
+
 <h3>Implementation</h3>
 
 The transformations are implemented as a replacement of the marker functions
@@ -121,7 +144,7 @@ erlang:apply/3 are not detected or rewritten and will result in a run time
 exception. The result of either transform is <em>always</em> a fun
 expression, even when no unevaluated arguments are found.
 
-The underscore variable "_" is used as a placeholder for unevaluated
+The underscore variable `_' is used as a placeholder for unevaluated
 arguments. It is only legal as a standalone expression, as either the function
 name to call or as an argument. Unevaluated arguments are converted to
 arguments of the created fun in strict left to right order. There is no
@@ -141,7 +164,7 @@ Fun = fun (Arg1) ->
 end.
 '''
 
-partial:cute/1 is implemented as a transformation from:
+`partial:cute/1' is implemented as a transformation from:
 
 ```
 Fun = partial:cute(some_fun(X, Y, _)).

--- a/doc/partial.md
+++ b/doc/partial.md
@@ -7,7 +7,35 @@
 
 A parse transform implementing partial function application.
 
-<a name="index"></a>
+<a name="description"></a>
+
+## Description ##
+
+To enable, add to the top of your module:
+
+```
+   -compile({parse_transform, partial}).
+```
+
+This will enable compile time conversion of calls to
+`partial:cut/1` and `partial:cute/1` into partial function
+application of the contained function. `_` is used as a marker for
+the unevaluated slot(s) in the contained function.
+
+With `partial:cut/1`, the arguments to the called function are
+evaluated when the returned function is applied. With
+`partial:cute/1`, the arguments are evaluated when the function is
+constructed.
+
+Additionally, a compile option can be specified via erlc options
+or by adding to the top of your module:
+
+```
+   -compile(partial_allow_local).
+```
+
+To enable transforming `cut/1` and `cute/1` the same as the fully
+qualified names.<a name="index"></a>
 
 ## Function Index ##
 
@@ -70,7 +98,11 @@ __See also:__ [parse_transform/2](#parse_transform-2).
 
 ### parse_transform/2 ###
 
-`parse_transform(Forms, Options) -> any()`
+<pre><code>
+parse_transform(Forms, Options) -&gt; NewForms
+</code></pre>
+
+<ul class="definitions"><li><code>Forms = [<a href="erl_parse.md#type-abstract_form">erl_parse:abstract_form()</a> | <a href="erl_parse.md#type-form_info">erl_parse:form_info()</a>]</code></li><li><code>Options = [<a href="compile.md#type-option">compile:option()</a>]</code></li><li><code>NewForms = [<a href="erl_parse.md#type-abstract_form">erl_parse:abstract_form()</a> | <a href="erl_parse.md#type-form_info">erl_parse:form_info()</a>]</code></li></ul>
 
 A parse transformation function which converts calls to special
 dummy functions in this module.

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,7 @@
 {profiles, [{native, [{erl_opts, [{native, o3},
                                   {d, 'NATIVE'}]}]
             },
-            {test, [{erl_opts, [{d, 'TEST'}]},
+            {test, [{erl_opts, [{d, 'PARTIAL_DEBUG'}]},
                     {deps, [proper]},
                     {plugins, [geas_rebar3,
                                rebar3_lint,

--- a/src/partial.app.src
+++ b/src/partial.app.src
@@ -1,6 +1,6 @@
 {application, partial,
  [{description, "Utility library for partial function application."},
-  {vsn, "1.1.0"},
+  {vsn, "1.2.0"},
   {applications, [kernel,
                   stdlib,
                   syntax_tools]},

--- a/test/test_partial.erl
+++ b/test/test_partial.erl
@@ -1,11 +1,16 @@
 %%%-------------------------------------------------------------------
 %%% @doc
-%%%
+%%% Tests for src/partial.erl
 %%% @end
 %%%-------------------------------------------------------------------
 -module(test_partial).
 
--compile({parse_transform, partial}).
+% This triggers the option error handling and prevents the rest of the
+% test from running.
+% -compile({partial_allow_local, invalid}).
+
+-compile([{parse_transform, partial},
+          partial_allow_local]).
 
 -export([dummy/0,
          dummy/1,
@@ -77,6 +82,10 @@ cut_test() ->
     Partial = partial:cut(dummy(1, _, 3)),
     ?assertEqual({1, 2, 3}, Partial(2)).
 
+cut_local_test() ->
+    Partial = cut(dummy(1, _, 3)),
+    ?assertEqual({1, 2, 3}, Partial(2)).
+
 cute_with_no_args_test() ->
     Partial = partial:cute(dummy()),
     ?assert(Partial()).
@@ -110,4 +119,8 @@ cute_module_function_name_test() ->
 
 cute_test() ->
     Partial = partial:cute(dummy(1, _, 3)),
+    ?assertEqual({1, 2, 3}, Partial(2)).
+
+cute_local_test() ->
+    Partial = cute(dummy(1, _, 3)),
     ?assertEqual({1, 2, 3}, Partial(2)).


### PR DESCRIPTION
This adds support for recognizing an unqualified cut/1 or cute/1 when the compiler option is given. It turns out have to parse the attributes in the parse transform to recognize them in the file, but it's not that bad.